### PR TITLE
TDRD-35: add a v1 retained data bucket (with permissions/kms)

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -6,6 +6,7 @@ data "aws_iam_policy_document" "v1_retained_data_bucket" {
       "s3:PutObject",
       "s3:GetObject",
       "s3:ListBucket",
+      "s3:GetBucketAcl",
     ]
 
     principals {

--- a/iam.tf
+++ b/iam.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "v1_retained_data_bucket" {
     ]
     principals {
       type        = "Service"
-      identifiers = "logs.eu-west-2.amazonaws.com"
+      identifiers = ["logs.eu-west-2.amazonaws.com"]
     }
     resources = [aws_s3_bucket.v1_retained_data.arn]
     condition {
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "v1_retained_data_bucket" {
     ]
     principals {
       type        = "Service"
-      identifiers = "logs.eu-west-2.amazonaws.com"
+      identifiers = ["logs.eu-west-2.amazonaws.com"]
     }
     resources = ["${aws_s3_bucket.v1_retained_data.arn}/*"]
     condition {

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,18 @@
+# S3 Policy
+
+data "aws_iam_policy_document" "v1_retained_data_bucket" {
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.tre_support_user_roles
+    }
+
+    resources = ["${aws_s3_bucket.v1_retained_data.arn}/*", aws_s3_bucket.v1_retained_data.arn]
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -5,15 +5,60 @@ data "aws_iam_policy_document" "v1_retained_data_bucket" {
     actions = [
       "s3:PutObject",
       "s3:GetObject",
-      "s3:ListBucket",
-      "s3:GetBucketAcl",
+      "s3:ListBucket"
     ]
 
     principals {
       type        = "AWS"
       identifiers = var.tre_support_user_roles
     }
-
     resources = ["${aws_s3_bucket.v1_retained_data.arn}/*", aws_s3_bucket.v1_retained_data.arn]
+  }
+
+  statement {
+    actions = [
+      "s3:GetBucketAcl",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = "logs.eu-west-2.amazonaws.com"
+    }
+    resources = [aws_s3_bucket.v1_retained_data.arn]
+    condition {
+      test     = "StringEquals"
+      values   = [var.account_id]
+      variable = "aws:SourceAccount"
+    }
+    condition {
+      test     = "ArnLike"
+      values   = ["arn:aws:logs:eu-west-2:${var.account_id}:log-group:*"]
+      variable = "aws:SourceArn"
+    }
+  }
+
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = "logs.eu-west-2.amazonaws.com"
+    }
+    resources = ["${aws_s3_bucket.v1_retained_data.arn}/*"]
+    condition {
+      test     = "StringEquals"
+      values   = [var.account_id]
+      variable = "aws:SourceAccount"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["bucket-owner-full-control"]
+      variable = "s3:x-amz-acl"
+    }
+    condition {
+      test     = "ArnLike"
+      values   = ["arn:aws:logs:eu-west-2:${var.account_id}:log-group:*"]
+      variable = "aws:SourceArn"
+    }
   }
 }

--- a/kms.tf
+++ b/kms.tf
@@ -1,11 +1,10 @@
 module "v1_retained_data_bucket_kms_key" {
-  source = "github.com/nationalarchives/da-terraform-modules//kms?ref=9518c81"
+  source = "github.com/nationalarchives/da-terraform-modules//kms?ref=5ec89e8"
   key_name = "${var.env}-${var.prefix}-v1-retained-data-kms"
   tags = {}
   default_policy_variables = {
     user_roles = var.tre_support_user_roles
-    ci_roles = [var.kms_key_administration_role]
-    service_names = ["cloudwatch"]
+    service_details = [{service_name = "logs.eu-west-2"}]
   }
   permissions_boundary = var.tre_permission_boundary_arn
 }

--- a/kms.tf
+++ b/kms.tf
@@ -4,6 +4,7 @@ module "v1_retained_data_bucket_kms_key" {
   tags = {}
   default_policy_variables = {
     user_roles = var.tre_support_user_roles
+    ci_roles = [var.kms_key_administration_role]
     service_details = [{service_name = "logs.eu-west-2"}]
   }
   permissions_boundary = var.tre_permission_boundary_arn

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,11 @@
+module "v1_retained_data_bucket_kms_key" {
+  source = "github.com/nationalarchives/da-terraform-modules//kms?ref=9518c81"
+  key_name = "${var.env}-${var.prefix}-v1-retained-data-kms"
+  tags = {}
+  default_policy_variables = {
+    user_roles = [var.tre_support_user_roles]
+    ci_roles = [var.kms_key_administration_role]
+    service_names = ["cloudwatch"]
+  }
+  permissions_boundary = var.tre_permission_boundary_arn
+}

--- a/kms.tf
+++ b/kms.tf
@@ -3,7 +3,7 @@ module "v1_retained_data_bucket_kms_key" {
   key_name = "${var.env}-${var.prefix}-v1-retained-data-kms"
   tags = {}
   default_policy_variables = {
-    user_roles = [var.tre_support_user_roles]
+    user_roles = var.tre_support_user_roles
     ci_roles = [var.kms_key_administration_role]
     service_names = ["cloudwatch"]
   }

--- a/s3.tf
+++ b/s3.tf
@@ -11,7 +11,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "v1_retained_data"
   bucket = aws_s3_bucket.v1_retained_data.id
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = module.v1_retained_data_bucket_kms_key.kms_key_alias
+      kms_master_key_id = module.v1_retained_data_bucket_kms_key.kms_key_arn
       sse_algorithm = "aws:kms"
     }
   }

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,33 @@
+resource "aws_s3_bucket" "v1_retained_data" {
+  bucket = "${var.env}-${var.prefix}-v1-retained-data"
+}
+
+resource "aws_s3_bucket_policy" "v1_retained_data" {
+  bucket = aws_s3_bucket.v1_retained_data.bucket
+  policy = data.aws_iam_policy_document.v1_retained_data_bucket.json
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "v1_retained_data" {
+  bucket = aws_s3_bucket.v1_retained_data.id
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = module.v1_retained_data_bucket_kms_key.kms_key_alias
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "v1_retained_data" {
+  bucket = aws_s3_bucket.v1_retained_data.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "v1_retained_data" {
+  bucket                  = aws_s3_bucket.v1_retained_data.bucket
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,24 @@
+variable "env" {
+  description = "Name of the environment to deploy"
+  type        = string
+}
+
+variable "prefix" {
+  description = "Transformation Engine prefix"
+  type        = string
+}
+
+variable "tre_permission_boundary_arn" {
+  description = "ARN of the TRE permission boundary policy"
+  type        = string
+}
+
+variable "tre_support_user_roles" {
+  description = "ARNs of roles used for AWS console debugging of the TRE system"
+  type        = list(string)
+}
+
+variable "kms_key_administration_role" {
+  description = "Role to administer kms keys"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,8 @@ variable "kms_key_administration_role" {
   description = "Role to administer kms keys"
   type        = string
 }
+
+variable "account_id" {
+  description = "Account ID for logs being copied in"
+  type        = string
+}


### PR DESCRIPTION
module in environments will have a conditional count so only makes on PROD (as we only retain data on prod).
There is a draft PR - until this in and versioned - in environments with that in for DEV (where I will test the copy of logs to bucket)